### PR TITLE
Fix CI jobs to work with GitHub upload/download actions v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,26 +20,32 @@ jobs:
           - os: ubuntu-20.04
             arch: "x86_64"
             build: "manylinux_"
+            artifact_suffix: "manylinux_x86_64"
             use_qemu: false
           - os: ubuntu-20.04
             arch: "aarch64"
             build: "manylinux_"
+            artifact_suffix: "manylinux_aarch64"
             use_qemu: true
           - os: ubuntu-20.04
             arch: "ppc64le"
             build: "manylinux_"
+            artifact_suffix: "manylinux_ppc64le"
             use_qemu: true
           - os: ubuntu-20.04
             arch: "s390x"
             build: "manylinux_"
+            artifact_suffix: "manylinux_s390x"
             use_qemu: true
           - os: windows-2019
             arch: "AMD64"
             build: ""
+            artifact_suffix: "windows_x86_64"
             use_qemu: false
           - os: macos-11
             arch: "x86_64 arm64"
             build: ""
+            artifact_suffix: "macos"
             use_qemu: false
 
     steps:
@@ -60,6 +66,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: artifact-${{matrix.artifact_suffix}}
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -75,7 +82,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: artifact-${{matrix.os}}${{matrix.build}}${{matrix.arch}}
+          name: artifact-sdist
           path: dist/*.tar.gz
 
   check_dist:
@@ -85,7 +92,6 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact-sdist
           path: dist
 
       - run: pipx run twine check --strict dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: dist
-
+          merge-multiple: true
       - run: pipx run twine check --strict dist/*
 
   pypi-publish:
@@ -107,9 +107,10 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-    - name: Download Python package dist artifacts
-      uses: actions/download-artifact@v4
-      with:
-        path: dist
-    - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Download Python package dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: artifact-${{matrix.os}}${{matrix.build}}${{matrix.arch}}
           path: dist/*.tar.gz
 
   check_dist:
@@ -84,7 +85,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          name: artifact-sdist
           path: dist
 
       - run: pipx run twine check --strict dist/*
@@ -103,7 +104,6 @@ jobs:
     - name: Download Python package dist artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifact
         path: dist
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The v4 updates to the upload and download artifact actions broke many CI workflows due to conflicting artifact names.